### PR TITLE
Swap using parameter with argument as appropriate.

### DIFF
--- a/src/main/tut/index.html
+++ b/src/main/tut/index.html
@@ -487,8 +487,8 @@ decodeCsv(input, _.toFloat)
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the argument is unspecified.
 
 ```tut:silent
 implicit val defaultInt: Int = 2
@@ -504,8 +504,8 @@ printInt
 
 ## Implicit resolution
 
-> When .highlight[a function expects a parameter of type `A`] _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the parameter is unspecified.
+> When .highlight[a function expects an argument to parameter of type `A`] _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the argument is unspecified.
 
 ```scala
 implicit val defaultInt: Int = 2
@@ -521,8 +521,8 @@ printInt
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is .highlight[marked as `implicit`] _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is .highlight[marked as `implicit`] _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the argument is unspecified.
 
 ```scala
 implicit val defaultInt: Int = 2
@@ -538,8 +538,8 @@ printInt
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> .highlight[value of type `A`] marked as `implicit` in scope, then the compiler will use that value if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> .highlight[value of type `A`] marked as `implicit` in scope, then the compiler will use that value if the argument is unspecified.
 
 ```scala
 implicit `val defaultInt: Int` = 2
@@ -555,8 +555,8 @@ printInt
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as .highlight[`implicit`] in scope, then the compiler will use that value if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as .highlight[`implicit`] in scope, then the compiler will use that value if the argument is unspecified.
 
 ```scala
 &#x200B;`implicit` val defaultInt: Int = 2
@@ -572,8 +572,8 @@ printInt
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then the compiler will use that value .highlight[if the parameter is unspecified].
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then the compiler will use that value .highlight[if the argument is unspecified].
 
 ```scala
 implicit val defaultInt: Int = 2
@@ -589,8 +589,8 @@ printInt`            `
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then .highlight[the compiler will use that value] if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then .highlight[the compiler will use that value] if the argument is unspecified.
 
 ```scala
 implicit val defaultInt: Int = 2
@@ -606,8 +606,8 @@ printInt`(defaultInt)`
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then .highlight[the compiler will use that value] if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then .highlight[the compiler will use that value] if the argument is unspecified.
 
 ```scala
 implicit val defaultInt: Int = 2
@@ -623,8 +623,8 @@ printInt(defaultInt)
 
 ## Implicit resolution
 
-> When a function expects a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
-> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the parameter is unspecified.
+> When a function expects an argument to a parameter of type `A` _and_ that parameter is marked as `implicit` _and_ there exists a
+> value of type `A` marked as `implicit` in scope, then the compiler will use that value if the argument is unspecified.
 
 ```scala
 implicit val defaultInt: Int = 2


### PR DESCRIPTION
Background, for example:
https://blog.kotlin-academy.com/programmer-dictionary-parameter-vs-argument-type-parameter-vs-type-argument-b965d2cc6929